### PR TITLE
Handle relative directory paths

### DIFF
--- a/src/extensionStore.js
+++ b/src/extensionStore.js
@@ -79,12 +79,14 @@ class ExtensionStore {
     }
 
     get directories() {
-        let configuration = vscode.workspace.getConfiguration("private-extension-manager")
+        let configuration = vscode.workspace.getConfiguration("private-extension-manager");
+
+        const rootDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
         return configuration.directories.map(d => {
             return {
                 name: path.parse(d).name,
-                path: d
+                path: path.resolve(rootDir, d),
             }
         })
     }


### PR DESCRIPTION
I noticed that directories had to be specified with absolute paths, but in my case I wanted to point it to a path relative to where my repo was cloned.
