### PR TITLE
Fix read unc paths

### DIFF
--- a/src/extensionStore.js
+++ b/src/extensionStore.js
@@ -10,7 +10,11 @@ function getExtensionFromDirectory(direcoryInfo) {
                 ((file[1] & vscode.FileType.File) == vscode.FileType.File))
             resolve(files.map(f => f[0]))
         }, (reason) => {
-            vscode.window.showWarningMessage('Unable to read directory. Please check extension settings.')
+            if (/\\\\[a-zA-Z0-9\.\-_]{1,}(\\[a-zA-Z0-9\-_]{1,}){1,}[\$]{0,1}/.test(direcoryInfo.path)) {
+                vscode.window.showWarningMessage('Unable to read directory. Please add the UNC host to the allowed list.')
+            } else {
+                vscode.window.showWarningMessage('Unable to read directory. Please check extension settings.')
+            }
             reject()
         })
     })
@@ -38,7 +42,7 @@ function distinctExtensionsWithAllVersions(extensions) {
     extensions.forEach(extension => {
         if (distinctExtensions[getExtensionIdentifier(extension)])
             return
-        
+
         extension.versions = extensions
             .filter(ex => getExtensionIdentifier(ex) === getExtensionIdentifier(extension))
             .sort((a, b) => compareVersions(a.version, b.version) * -1)
@@ -94,15 +98,15 @@ class ExtensionStore {
 
     extensionInDirectory(directory) {
         return getExtensionFromDirectory(directory)
-        .then(extensionFiles => {
-            return Promise.all(extensionFiles.map(file => {
-                return loadExtensionFile(path.join(directory.path, file))
-            }))
-        })
-        .then(filterAndFormatExtensionInfos)
-        .catch(err => {
-            console.log(err)
-        })
+            .then(extensionFiles => {
+                return Promise.all(extensionFiles.map(file => {
+                    return loadExtensionFile(path.join(directory.path, file))
+                }))
+            })
+            .then(filterAndFormatExtensionInfos)
+            .catch(err => {
+                console.log(err)
+            })
     }
 
     refresh() {

--- a/src/provider/extensionsTreeProvider.js
+++ b/src/provider/extensionsTreeProvider.js
@@ -23,34 +23,38 @@ class ExtensionProvider {
     getChildren(element) {
         if (element) {
             return extensionStore.extensionInDirectory(element).then(extensions => {
-                return extensions.map(extension => new Extension(extension))
+                try {
+                    return extensions.map(extension => new Extension(extension))
+                } catch (ex) {
+                    return undefined;
+                }
             })
         }
-        
+
         return extensionStore.directories.map(directory => new DirectoryExtension(directory))
     }
 }
 
 class DirectoryExtension extends vscode.TreeItem {
 
-	constructor(directory) {
+    constructor(directory) {
         super(directory.name, vscode.TreeItemCollapsibleState.Collapsed)
         this.path = directory.path
         this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
-	}
+    }
 
-	get tooltip() {
-		return this.path
-	}
+    get tooltip() {
+        return this.path
+    }
 
-	get description() {
-		return this.path
-	}
+    get description() {
+        return this.path
+    }
 }
 
 class Extension extends vscode.TreeItem {
 
-	constructor(extension) {
+    constructor(extension) {
         super(extension.displayName, vscode.TreeItemCollapsibleState.None)
         this.publisher = extension.publisher
         this.displayName = extension.displayName
@@ -70,22 +74,22 @@ class Extension extends vscode.TreeItem {
             const image = extension.contextValue === 'extension-not-installed' ? 'install.svg' : 'update.svg'
 
             this.iconPath = {
-                light: path.join(__dirname, '..','..', 'media', 'light', image),
-                dark: path.join(__dirname, '..','..', 'media', 'dark', image)
+                light: path.join(__dirname, '..', '..', 'media', 'light', image),
+                dark: path.join(__dirname, '..', '..', 'media', 'dark', image)
             }
         }
-	}
+    }
 
-	get tooltip() {
-		return `${this.publisher}.${this.name}-${this.version}`
-	}
+    get tooltip() {
+        return `${this.publisher}.${this.name}-${this.version}`
+    }
 
-	get description() {
-		return `${this.publisher} (${this.version})`
-	}
+    get description() {
+        return `${this.publisher} (${this.version})`
+    }
 }
 
-module.exports = function() {
+module.exports = function () {
     const extensionProvider = new ExtensionProvider()
     vscode.window.registerTreeDataProvider('privateExtensions', extensionProvider)
     return extensionProvider


### PR DESCRIPTION
In case of error it checks for UNC paths and show appropriate message.
No more `Cannot read property of undefined (reading 'map')` error message.

Fixes #32 